### PR TITLE
feat: Implement Full CRUD for Workflow Builder Steps

### DIFF
--- a/components/workflow/edit-step-modal.tsx
+++ b/components/workflow/edit-step-modal.tsx
@@ -1,0 +1,112 @@
+"use client"
+
+import { useState, useEffect } from "react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Label } from "@/components/ui/label"
+import { type WorkflowStep } from "@/lib/workflow-api"
+
+interface EditStepModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onSave: (updatedStep: WorkflowStep) => void
+  step: WorkflowStep | null
+}
+
+export function EditStepModal({ isOpen, onClose, onSave, step }: EditStepModalProps) {
+  const [title, setTitle] = useState("")
+  const [description, setDescription] = useState("")
+  const [duration, setDuration] = useState("")
+
+  useEffect(() => {
+    if (step) {
+      setTitle(step.title)
+      setDescription(step.description)
+      setDuration(step.duration)
+    }
+  }, [step])
+
+  const handleSave = () => {
+    if (!step) return
+
+    const updatedStep = {
+      ...step,
+      title,
+      description,
+      duration,
+    }
+    onSave(updatedStep)
+    onClose()
+  }
+
+  // Handle the open state change of the dialog to call our onClose prop
+  // when the user closes it via escape key or clicking outside.
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      onClose()
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-[425px] bg-navy-800 border-navy-700 text-white">
+        <DialogHeader>
+          <DialogTitle>Edit Step</DialogTitle>
+          <DialogDescription className="text-navy-300">
+            Make changes to your workflow step here. Click save when you're done.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="title" className="text-right text-navy-300">
+              Title
+            </Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              className="col-span-3 bg-navy-900 border-navy-600 placeholder:text-navy-400"
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="description" className="text-right text-navy-300">
+              Description
+            </Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              className="col-span-3 bg-navy-900 border-navy-600 placeholder:text-navy-400"
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <Label htmlFor="duration" className="text-right text-navy-300">
+              Duration
+            </Label>
+            <Input
+              id="duration"
+              value={duration}
+              onChange={(e) => setDuration(e.target.value)}
+              className="col-span-3 bg-navy-900 border-navy-600 placeholder:text-navy-400"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose} className="text-white border-navy-600 hover:bg-navy-700">
+            Cancel
+          </Button>
+          <Button onClick={handleSave} className="bg-violet-600 hover:bg-violet-700 text-white">Save changes</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/lib/workflow-api.ts
+++ b/lib/workflow-api.ts
@@ -1,0 +1,183 @@
+// lib/workflow-api.ts
+
+import { type LucideIcon } from "lucide-react"
+
+// Define the core data structures based on the minimal schema
+// In a real app, the LucideIcon type would likely be just a string
+// representing the icon's name, stored in the database.
+export interface WorkflowStep {
+  id: number
+  title: string
+  icon: string // Name of the Lucide icon
+  description: string
+  color: string
+  duration: string
+  automated: boolean
+}
+
+export interface Workflow {
+  id: string
+  name: string
+  description: string
+  userId: string
+  steps: WorkflowStep[]
+  // Future fields
+  // price: number;
+  // templateId: string;
+}
+
+export interface User {
+  id: string
+  name: string
+  email: string
+}
+
+// --- MOCKED DATABASE ---
+// This simulates a database for development purposes.
+let mockWorkflows: Workflow[] = [
+  {
+    id: "wf_1",
+    name: "UK Student Visa Process",
+    description: "Complete visa application support with document review and interview prep",
+    userId: "user_1",
+    steps: [
+      {
+        id: 1,
+        title: "Initial Consultation",
+        icon: "MessageSquare",
+        description: "30-min discovery call",
+        color: "bg-violet-500",
+        duration: "30 minutes",
+        automated: false,
+      },
+      {
+        id: 2,
+        title: "Document Collection",
+        icon: "Upload",
+        description: "Secure document upload",
+        color: "bg-emerald-500",
+        duration: "2-3 days",
+        automated: true,
+      },
+      {
+        id: 3,
+        title: "Application Review",
+        icon: "FileText",
+        description: "Expert application review",
+        color: "bg-navy-500",
+        duration: "1-2 days",
+        automated: false,
+      },
+      {
+        id: 4,
+        title: "Interview Preparation",
+        icon: "Calendar",
+        description: "Mock interview session",
+        color: "bg-violet-600",
+        duration: "1 hour",
+        automated: false,
+      },
+      {
+        id: 5,
+        title: "Final Submission",
+        icon: "CheckCircle",
+        description: "Application submission",
+        color: "bg-emerald-600",
+        duration: "1 day",
+        automated: true,
+      },
+    ],
+  },
+]
+
+// --- MOCKED API FUNCTIONS ---
+// These functions simulate making API calls to a backend.
+
+const simulateApiLatency = () => new Promise((resolve) => setTimeout(resolve, 300))
+
+export const getWorkflow = async (workflowId: string): Promise<Workflow | undefined> => {
+  await simulateApiLatency()
+  console.log(`API: Fetching workflow ${workflowId}`)
+  return mockWorkflows.find((wf) => wf.id === workflowId)
+}
+
+export const addWorkflowStep = async (
+  workflowId: string,
+  newStepData: Omit<WorkflowStep, "id">,
+): Promise<WorkflowStep> => {
+  await simulateApiLatency()
+  const workflow = mockWorkflows.find((wf) => wf.id === workflowId)
+  if (!workflow) {
+    throw new Error("Workflow not found")
+  }
+
+  const newStep: WorkflowStep = {
+    ...newStepData,
+    id: Math.max(0, ...workflow.steps.map((s) => s.id)) + 1,
+  }
+
+  workflow.steps.push(newStep)
+  console.log(`API: Added step "${newStep.title}" to workflow ${workflowId}`)
+  return newStep
+}
+
+export const updateWorkflowStep = async (workflowId: string, updatedStep: WorkflowStep): Promise<WorkflowStep> => {
+  await simulateApiLatency()
+  const workflow = mockWorkflows.find((wf) => wf.id === workflowId)
+  if (!workflow) {
+    throw new Error("Workflow not found")
+  }
+
+  const stepIndex = workflow.steps.findIndex((s) => s.id === updatedStep.id)
+  if (stepIndex === -1) {
+    throw new Error("Step not found")
+  }
+
+  workflow.steps[stepIndex] = updatedStep
+  console.log(`API: Updated step "${updatedStep.title}" in workflow ${workflowId}`)
+  return updatedStep
+}
+
+export const deleteWorkflowStep = async (workflowId: string, stepId: number): Promise<{ success: true }> => {
+  await simulateApiLatency()
+  const workflow = mockWorkflows.find((wf) => wf.id === workflowId)
+  if (!workflow) {
+    throw new Error("Workflow not found")
+  }
+
+  const initialLength = workflow.steps.length
+  workflow.steps = workflow.steps.filter((s) => s.id !== stepId)
+
+  if (workflow.steps.length === initialLength) {
+    throw new Error("Step not found to delete")
+  }
+
+  console.log(`API: Deleted step with id ${stepId} from workflow ${workflowId}`)
+  return { success: true }
+}
+
+export const reorderWorkflowSteps = async (workflowId: string, orderedStepIds: number[]): Promise<WorkflowStep[]> => {
+  await simulateApiLatency()
+  const workflow = mockWorkflows.find((wf) => wf.id === workflowId)
+  if (!workflow) {
+    throw new Error("Workflow not found")
+  }
+
+  const newSteps: WorkflowStep[] = []
+  const stepMap = new Map(workflow.steps.map((step) => [step.id, step]))
+
+  for (const id of orderedStepIds) {
+    const step = stepMap.get(id)
+    if (step) {
+      newSteps.push(step)
+    }
+  }
+
+  if (newSteps.length !== workflow.steps.length) {
+    throw new Error("Mismatch in step IDs during reorder")
+  }
+
+  workflow.steps = newSteps
+  console.log(`API: Reordered steps for workflow ${workflowId}`)
+  return workflow.steps
+}


### PR DESCRIPTION
This commit introduces full Create, Read, Update, and Delete (CRUD) functionality for the steps within the Workflow Builder.

Key changes include:
- A simulated API layer (`lib/workflow-api.ts`) has been created to handle data persistence, defining the data structures and API contract for workflows.
- A new modal (`components/workflow/edit-step-modal.tsx`) has been created to allow you to edit the details of a workflow step.
- The main builder page (`app/workflow/builder/page.tsx`) has been refactored to use the API layer for all data manipulations (add, edit, delete), replacing the previous hardcoded state.
- The builder now fetches its initial state from the API, and all changes are persisted through API calls.